### PR TITLE
Upgrading to `AGP 8`

### DIFF
--- a/applist_detector_flutter/android/build.gradle
+++ b/applist_detector_flutter/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace "com.ahmed.applist_detector_flutter"
     compileSdkVersion 33
     ndkVersion "25.0.8775105"
 


### PR DESCRIPTION
As I'm using Gradle v`8.x.x` in one of my projects, so it's a must that all plugins satisfy that. So I resolved that in your package by adding `namespace` property inside `build.gradle` instead of only `package` property inside `AndroidManifest.xml`.